### PR TITLE
Add minting in authorise

### DIFF
--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^17.0.3",
         "@types/react-dom": "^17.0.3",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "eslint": "8.10.0",
+        "eslint": "^8.10.0",
         "eslint-config-next": "12.1.0",
         "eslint-config-prettier": "^8.4.0",
         "prettier": "^2.5.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
-    "eslint": "8.10.0",
+    "eslint": "^8.10.0",
     "eslint-config-next": "12.1.0",
     "eslint-config-prettier": "^8.4.0",
     "prettier": "^2.5.1",

--- a/src/app/src/lib/getaccs.ts
+++ b/src/app/src/lib/getaccs.ts
@@ -5,9 +5,8 @@ const { abi } = _abi
 
 
 function replaceId(str: string, id: number) {
-  // const idHex = id.toString(16).padStart(64, '0');
-  const paddedId = id.toString().padStart(64, '0')
-  return str.replace(/\{id\}/g, paddedId);
+  const idHex = id.toString(16).padStart(64, '0');
+  return str.replace(/\{id\}/g, idHex);
 }
 
 export async function getAccoladesByContract(address: string, contract: Contract) {

--- a/src/app/src/pages/api/batchmint.ts
+++ b/src/app/src/pages/api/batchmint.ts
@@ -13,9 +13,9 @@ export default async function Mint(req: NextApiRequest, res: NextApiResponse) {
     // Assumes a correct environment setup
     const wallet = new ethers.Wallet(privateKey!, provider);
 
-    // const amounts = new Array(tokenIds.length).fill(1);
-    // const contract = new ethers.Contract(contractAddress, abi, wallet);
-    // const tx = await contract.mintBatch(address, tokenIds, amounts, "0x00");
+    const amounts = new Array(tokenIds.length).fill(1);
+    const contract = new ethers.Contract(contractAddress, abi, wallet);
+    const tx = await contract.mintBatch(address, tokenIds, amounts, "0x00");
 
     res.status(200).json({ tokens: tokenIds });
   } catch (error) {

--- a/src/app/src/pages/api/batchmint.ts
+++ b/src/app/src/pages/api/batchmint.ts
@@ -1,0 +1,24 @@
+  import { ethers } from "ethers";
+import { NextApiRequest, NextApiResponse } from "next";
+import _abi from "../../lib/abi.json";
+const { abi } = _abi
+
+export default async function Mint(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { contractAddress, address, tokenIds } = req.body;
+
+    const url = process.env.RINKEBY_URL;
+    const provider = new ethers.providers.JsonRpcProvider(url);
+    const privateKey = process.env.PRIVATE_KEY;
+    // Assumes a correct environment setup
+    const wallet = new ethers.Wallet(privateKey!, provider);
+
+    // const amounts = new Array(tokenIds.length).fill(1);
+    // const contract = new ethers.Contract(contractAddress, abi, wallet);
+    // const tx = await contract.mintBatch(address, tokenIds, amounts, "0x00");
+
+    res.status(200).json({ tokens: tokenIds });
+  } catch (error) {
+    res.send(500);
+  }
+}


### PR DESCRIPTION
Fetch eligible tokens from "centralised server" and fetch owned tokens on contract by user; cross-compare the two and display the unclaimed tokens; allow users to batch mint tokens and then display a hint that tokens are being minted; re-minting tokens is disallowed but as of yet only saved in state (meaning that if a user refreshes before the transaction is done, they could remint the tokens)